### PR TITLE
Mutation keys

### DIFF
--- a/src/hook-file.ts
+++ b/src/hook-file.ts
@@ -164,6 +164,7 @@ export class HookFile extends ModuleBuilder {
         yield `  const queryClient = ${useQueryClient()}();`;
         yield `  const ${serviceName} = ${this.context.fn(serviceHookName)}()`;
         yield `  return ${useMutation()}({`;
+        yield `    mutationKey: ${this.buildQueryKey(httpPath, method)},`;
         yield `    mutationFn: async (${paramsExpression}) => {`;
         yield `      const res = await ${guard()}(${serviceName}.${camel(
           method.name.value,

--- a/src/hook-file.ts
+++ b/src/hook-file.ts
@@ -160,7 +160,7 @@ export class HookFile extends ModuleBuilder {
           undefined,
           method.deprecated?.value,
         );
-        const mutationKey = [this.buildQueryKey(httpPath, method), { method }];
+        const mutationKey = `['${method.name.value}']`;
         yield `export function ${name}(${optionsExpression}) {`;
         yield `  const queryClient = ${useQueryClient()}();`;
         yield `  const ${serviceName} = ${this.context.fn(serviceHookName)}()`;

--- a/src/hook-file.ts
+++ b/src/hook-file.ts
@@ -160,11 +160,12 @@ export class HookFile extends ModuleBuilder {
           undefined,
           method.deprecated?.value,
         );
+        const mutationKey = [this.buildQueryKey(httpPath, method), { method }];
         yield `export function ${name}(${optionsExpression}) {`;
         yield `  const queryClient = ${useQueryClient()}();`;
         yield `  const ${serviceName} = ${this.context.fn(serviceHookName)}()`;
         yield `  return ${useMutation()}({`;
-        yield `    mutationKey: [${method} ${this.buildQueryKey(httpPath, method)}],`;
+        yield `    mutationKey: ${mutationKey},`;
         yield `    mutationFn: async (${paramsExpression}) => {`;
         yield `      const res = await ${guard()}(${serviceName}.${camel(
           method.name.value,
@@ -193,6 +194,8 @@ export class HookFile extends ModuleBuilder {
         yield `    ...options,`;
         yield `  });`;
         yield `}`;
+
+        yield `${name}.mutationKey = ${mutationKey}`;
       }
 
       if (isGet && this.isRelayPaginated(method)) {

--- a/src/hook-file.ts
+++ b/src/hook-file.ts
@@ -164,7 +164,7 @@ export class HookFile extends ModuleBuilder {
         yield `  const queryClient = ${useQueryClient()}();`;
         yield `  const ${serviceName} = ${this.context.fn(serviceHookName)}()`;
         yield `  return ${useMutation()}({`;
-        yield `    mutationKey: ${this.buildQueryKey(httpPath, method)},`;
+        yield `    mutationKey: [${method} ${this.buildQueryKey(httpPath, method)}],`;
         yield `    mutationFn: async (${paramsExpression}) => {`;
         yield `      const res = await ${guard()}(${serviceName}.${camel(
           method.name.value,
@@ -481,7 +481,7 @@ export class HookFile extends ModuleBuilder {
     }
 
     if (options?.infinite) {
-      queryKey.push('{inifinite: true}');
+      queryKey.push('{infinite: true}');
     }
 
     return `[${queryKey.join(', ')}]${


### PR DESCRIPTION
- feat: Adds a `mutationKey` to allow for getting the status of a mutation via `useMutationState` more easily.

- fix: Fixes a misspelling for queryOptions.infinite in `buildQueryKey`

Expected usage:

```tsx
import { useCreatePost } from '@/src/__generated__/hooks/post';

const MyComponent = () => {
  const createPost = useCreatePost();

  return (
    <button 
      onClick={() => createPost.mutate({ message: 'hello world' })}
    >
      Create Post
    </button>
  );
}

// Elsewhere:
import { useMutationState } from '@tanstack/query';
import { useCreatePost } from '__generated__/hooks/post';

const MyListeningComponent = () => {
  const createPostState = useMutationState({
    filters: { 
      mutationKey: useCreatePost.mutationKey,
      predicate: (mutation) => mutation.state.variables?.message === 'hello world',
    },
  });
 
  return createPostState.state.status === 'pending' 
    ? <Loading /> 
    : <p>Post created!</p>;
};
```